### PR TITLE
Newsletter: simplify MJML templates + add README (light theme)

### DIFF
--- a/news/mjml/README.md
+++ b/news/mjml/README.md
@@ -1,0 +1,157 @@
+# Newsletter templates (MJML)
+
+This folder contains MJML templates for the EEF newsletter. The goal is to keep the design consistent with EEF’s visual identity while making it **easy for any volunteer to edit** without breaking layout.
+
+## What you need
+
+- MJML (CLI or VS Code extension)
+- This repo / folder
+
+Recommended:
+- VS Code + “MJML” extension
+
+## Files
+
+- `template-base.mjml`  
+  The starter template. Minimal MJML structure + a single “content-first” block that uses mostly `p`, `ul`, `li`.  
+  Best for contributors who just want to write/update content safely.
+
+- `newsletter-example.mjml` (optional, if present)  
+  A filled-in example using the same patterns.
+
+## Core principle (very important)
+
+**Edit content, not layout.**
+
+Do edit:
+- text, links, list items, headings inside the content block
+
+Don’t edit:
+- MJML attributes
+- section padding / wrapper settings
+- CSS class definitions
+
+If you’re unsure, only edit between the **“TEMPLATE CONTENT START/END”** comments.
+
+## Placeholders to replace
+
+- `{{BROWSER_URL}}`  
+  Link to the hosted HTML “browser version” of the newsletter.
+
+- `{{PREVIEW_TEXT}}`  
+  The short preview text some email clients show next to the subject.
+
+- `{{NEWSLETTER_TITLE}}`  
+  Usually “Erlang Ecosystem Foundation”.
+
+- `{{NEWSLETTER_DATE}}`  
+  e.g. “January 2026 Newsletter”.
+
+Depending on your pipeline, these may be replaced by a script or manually.
+
+## How to write content (patterns)
+
+### Section title
+
+```html
+<p class="section-title">Coming up</p>
+```
+
+### Subsection title
+
+```html
+<p class="sub-title"><span class="u-underline">FOSDEM</span></p>
+```
+
+### Generic card (paragraph + list)
+
+```html
+<div class="card">
+  <p>Your paragraph text here.</p>
+  <ul>
+    <li>Bullet one</li>
+    <li>Bullet two</li>
+  </ul>
+  <p class="muted">Optional muted line.</p>
+</div>
+```
+
+### Event card (eyebrow + left accent + CTA link)
+
+```html
+<div class="card">
+  <p class="eyebrow">CodeBEAM Europe (Berlin)</p>
+  <div class="accent">
+    <ul>
+      <li>Point one</li>
+      <li>Point two</li>
+    </ul>
+    <p class="cta-wrap">
+      <a class="cta" href="https://example.com" target="_blank">Watch the videos</a>
+    </p>
+  </div>
+</div>
+```
+
+### Divider
+
+```html
+<div class="hr"></div>
+```
+
+### Bold emphasis (preferred)
+
+Some clients can be inconsistent with `strong`/`b`. Use:
+
+```html
+<span class="bold">Important label:</span>
+```
+
+### Inline code
+
+```html
+<code>gen_statem</code>
+```
+
+## Build / preview
+
+### Option A: MJML CLI
+
+1) Install MJML  
+```bash
+npm install -g mjml
+```
+
+2) Compile  
+```bash
+mjml path/to/file.mjml -o output.html
+```
+
+3) Open `output.html` in a browser.
+
+### Option B: VS Code
+
+- Install the MJML extension.
+- Use the preview / compile command from the extension.
+
+## Common pitfalls
+
+- Don’t add a space inside tags like `< mj-font ... />` — it’s invalid and can break parsing.
+- Avoid inline `style="margin:..."` inside `p` or `li`. Spacing is handled globally by the template.
+- Keep the structure “content-first”: use `p`, `ul`, `li`, and the provided classes.
+
+## Making a new newsletter
+
+1) Copy `template-base.mjml` to a new file (e.g. `YYYY-MM-DD.mjml`).
+2) Update:
+   - `{{PREVIEW_TEXT}}`
+   - `{{NEWSLETTER_DATE}}`
+   - `{{BROWSER_URL}}` (once you know the final URL)
+3) Replace the content inside the content block.
+4) Compile to HTML and do a quick visual check (at least in a browser).
+5) Commit and open a PR.
+
+If you want to propose a new pattern, keep it:
+- minimal MJML changes
+- content-first (mostly HTML tags)
+- safe for contributors (low risk of breaking layout)

--- a/news/mjml/template-example.mjml
+++ b/news/mjml/template-example.mjml
@@ -1,203 +1,256 @@
 <mjml>
   <mj-head>
-    <mj-font name="Montserrat" href="https://fonts.googleapis.com/css?family=Montserrat" />
+    <mj-font name="Montserrat" href="https://fonts.googleapis.com/css?family=Montserrat:400,700" />
     <mj-preview>EEF updates: FOSDEM, CodeBEAM, security work, and sponsor news.</mj-preview>
+
     <mj-attributes>
       <mj-all font-family="Montserrat, Arial, Helvetica, sans-serif" />
-      <mj-text font-size="14px" line-height="20px" color="#d6dde1" font-weight="400" padding="0" />
-      <mj-divider border-width="1px" border-color="#2c3c46" padding="0" />
-      <mj-button font-family="Montserrat, Arial, Helvetica, sans-serif" font-weight="700" />
-      <!-- Type scale -->
-      <mj-class name="utility" font-size="12px" line-height="16px" color="#8fa3ad" font-weight="400" />
-      <mj-class name="h1" font-size="24px" line-height="30px" color="#f2f2f2" font-weight="700" />
-      <mj-class name="h2" font-size="18px" line-height="24px" color="#49b7ff" font-weight="700" />
-      <mj-class name="h3" font-size="16px" line-height="22px" color="#f2f2f2" font-weight="700" />
-      <!-- NEW: subsection heading (white, bigger, clear hierarchy) -->
-      <mj-class name="subHeading" font-size="18px" line-height="24px" color="#f2f2f2" font-weight="700" />
-      <!-- NEW: UI building blocks -->
-      <mj-class name="barSection" background-color="#10181f" border="1px solid #2c3c46" padding="12px 14px" />
-      <mj-class name="barSub" background-color="#10181f" border="1px solid #2c3c46" padding="10px 14px" />
-      <mj-class name="card" background-color="#162028" border="1px solid #2c3c46" padding="14px 16px" />
-      <!-- Buttons -->
-      <mj-class name="btnPrimary" background-color="#49b7ff" color="#0f1317" font-size="14px" border-radius="10px" inner-padding="12px 16px" />
-      <mj-class name="btnSecondary" background-color="#0f1317" color="#49b7ff" font-size="13px" border="1px solid #2c3c46" border-radius="10px" inner-padding="10px 14px" />
+      <mj-section background-color="#ffffff" />
+      <mj-text font-size="14px" line-height="20px" color="#1f2c34" font-weight="400" padding="0" />
+      <mj-divider border-width="1px" border-color="#d6dde1" padding="0" />
+      <mj-class name="utility" font-size="12px" line-height="16px" color="#5a6b75" font-weight="400" />
+      <mj-class name="h1" font-size="24px" line-height="30px" color="#1f2c34" font-weight="700" />
     </mj-attributes>
-    <mj-style inline="inline"> a, a:link, a:visited, a:hover, a:active { color:#49b7ff; text-decoration:none; font-weight:700 !important; } b, strong { font-weight:700 !important; } ul, ol { margin:0; padding-left:18px; } li { margin:0 0 8px 0; } /* Preferible a text-decoration-thickness/offset (mejor compatibilidad) */ .u-underline { display:inline-block; border-bottom:2px solid #49b7ff; padding-bottom:2px; } </mj-style>
+
+    <!-- Keep styling centralized so editors only touch p/ul/li text -->
+    <mj-style inline="inline">
+      a, a:link, a:visited, a:hover, a:active { color:#49b7ff; text-decoration:none; font-weight:700 !important; }
+
+      p { margin: 0 0 10px 0; }
+      ul, ol { margin: 0; padding-left: 18px; }
+      li { margin: 0 0 8px 0; }
+
+      code { font-family: monospace; }
+
+      .bold { font-weight: 700; }
+
+      .section-title {
+        margin: 18px 0 10px 0;
+        color: #49b7ff;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+
+      .sub-title {
+        margin: 32px 0 10px 0;
+        color: #1f2c34;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+
+      .u-underline { display:inline-block; border-bottom:2px solid #49b7ff; padding-bottom:2px; }
+
+      .card { margin: 0 0 14px 0; padding: 0; }
+
+      .eyebrow {
+        margin: 0 0 8px 0;
+        color: #5a6b75;
+        font-size: 12px;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+
+      .accent { border-left: 4px solid #49b7ff; padding-left: 12px; }
+
+      .muted { color: #5a6b75; font-size: 12px; line-height: 18px; }
+
+      .cta {
+        display: inline-block;
+        padding: 10px 14px;
+        border: 1px solid #c8d2d9;
+        border-radius: 10px;
+        background: #ffffff;
+        color: #49b7ff !important;
+        font-weight: 700 !important;
+        text-decoration: none !important;
+      }
+
+      .cta-wrap { margin: 12px 0 0 0; }
+
+      .hr { height: 1px; background: #d6dde1; margin: 16px 0; }
+    </mj-style>
   </mj-head>
-  <mj-body background-color="#ffffff" width="600px">
+
+  <mj-body background-color="#fafafa" width="600px">
+
     <!-- Utility row -->
-    <mj-section background-color="#ffffff" padding="24px 12px 12px">
+    <mj-section padding="24px 12px 12px">
       <mj-column>
         <mj-text mj-class="utility" align="center" padding="0 12px">
           <a href="{{BROWSER_URL}}" target="_blank">Browser version ➚</a>
         </mj-text>
       </mj-column>
     </mj-section>
+
     <!-- Main container -->
-    <mj-wrapper background-color="#1f2c34" padding="0">
+    <mj-wrapper background-color="#ffffff" padding="0">
+
       <!-- Header -->
-      <mj-section background-color="#1f2c34" padding="20px 24px 12px">
+      <mj-section padding="20px 24px 12px">
         <mj-column>
           <mj-image width="120px" src="https://erlef.org/images/EEF_Isotipo.png" alt="EEF Logo" align="left" padding="0" />
           <mj-text mj-class="h1" padding="12px 0 0 0">Erlang Ecosystem Foundation</mj-text>
           <mj-text mj-class="utility" padding="6px 0 0 0">January 2026 Newsletter</mj-text>
         </mj-column>
       </mj-section>
-      <mj-section background-color="#1f2c34" padding="0 24px">
+
+      <mj-section padding="0 24px"><mj-column><mj-divider /></mj-column></mj-section>
+
+      <!-- CONTENT: edit mostly with p/ul/li -->
+      <mj-section padding="0 24px 18px">
         <mj-column>
-          <mj-divider />
-        </mj-column>
-      </mj-section>
-      <!-- ========================= -->
-      <!-- SECTION: Coming up        -->
-      <!-- ========================= -->
-      <mj-section background-color="#1f2c34" padding="18px 24px 0">
-        <mj-column>
-          <mj-text mj-class="h2 barSection">Coming up</mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- SUBSECTION: FOSDEM -->
-      <mj-section background-color="#1f2c34" padding="10px 24px 10px">
-        <mj-column>
-          <mj-text mj-class="subHeading barSub" align="left">
-            <span class="u-underline">FOSDEM</span>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- Card: FOSDEM -->
-      <mj-section background-color="#1f2c34" padding="0 24px 16px">
-        <mj-column>
-          <mj-text mj-class="card">
-            <p style="margin:0;"> The EEF will be at <a href="https://fosdem.org/2026/" target="_blank">FOSDEM</a> representing and advocating for the ecosystem and sustainability. We have two speaking slots: </p>
-            <ul style="margin:10px 0 0 18px; padding:0;">
-              <li><strong style="color:#f2f2f2;">Code and Compliance:</strong> “Scaling Security from Zero”, presented by Jonatan Männchen</li>
-              <li><strong style="color:#f2f2f2;">Funding the FOSS Ecosystem:</strong> “Build your funding toolkit”, presented by Daniel Janowski</li>
-            </ul>
-            <p style="margin:12px 0 0 0; color:#8fa3ad; font-size:12px; line-height:18px;"> If you’ll be there, find us on the EEF Slack and let us know. </p>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- Divider -->
-      <mj-section background-color="#1f2c34" padding="0 24px">
-        <mj-column>
-          <mj-divider />
-        </mj-column>
-      </mj-section>
-      <!-- =============================== -->
-      <!-- SECTION: What’s been happening  -->
-      <!-- =============================== -->
-      <mj-section background-color="#1f2c34" padding="18px 24px 0">
-        <mj-column>
-          <mj-text mj-class="h2 barSection">What’s been happening</mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- SUBSECTION: Events -->
-      <mj-section background-color="#1f2c34" padding="10px 24px 10px">
-        <mj-column>
-          <mj-text mj-class="subHeading barSub" align="left">
-            <span class="u-underline">Events</span>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- Card: CodeBEAM Europe -->
-      <mj-section background-color="#1f2c34" padding="0 24px 12px">
-        <mj-column>
-          <mj-text mj-class="card">
-            <p style="margin:0 0 8px 0; color:#8fa3ad; font-size:12px; letter-spacing:.02em; text-transform:uppercase;"> CodeBEAM Europe (Berlin) </p>
-            <div style="border-left:4px solid #49b7ff; padding-left:12px;">
-              <ul style="margin:0 0 0 18px; padding:0;">
-                <li> A dedicated Gleam track bringing together Gleamers and the curious. A tidy foreshadowing of <a href="https://gleamgathering.com/" target="_blank">GleamGathering</a> on 21 Feb in Bristol, UK. </li>
+          <mj-text>
+
+            <p class="section-title">Coming up</p>
+
+            <p class="sub-title"><span class="u-underline">FOSDEM</span></p>
+
+            <div class="card">
+              <p>
+                The EEF will be at <a href="https://fosdem.org/2026/" target="_blank">FOSDEM</a> representing and advocating
+                for the ecosystem and sustainability. We have two speaking slots:
+              </p>
+
+              <ul>
+                <li><span class="bold">Code and Compliance:</span> “Scaling Security from Zero”, presented by Jonatan Männchen</li>
+                <li><span class="bold">Funding the FOSS Ecosystem:</span> “Build your funding toolkit”, presented by Daniel Janowski</li>
+              </ul>
+
+              <p class="muted">If you’ll be there, find us on the EEF Slack and let us know.</p>
+            </div>
+
+            <div class="hr"></div>
+
+            <p class="section-title">What’s been happening</p>
+
+            <p class="sub-title"><span class="u-underline">Events</span></p>
+
+            <div class="card">
+              <p class="eyebrow">CodeBEAM Europe (Berlin)</p>
+
+              <div class="accent">
+                <ul>
+                  <li>
+                    A dedicated Gleam track bringing together Gleamers and the curious. A tidy foreshadowing of
+                    <a href="https://gleamgathering.com/" target="_blank">GleamGathering</a> on 21 Feb in Bristol, UK.
+                  </li>
+                  <li>
+                    <a href="https://atomvm.org" target="_blank">AtomVM</a> had talks covering the platform, the new JIT, and a lightning talk too.
+                    Conspiracy pundits expect next year’s CodeBEAM to have four AtomVM appearances.
+                  </li>
+                  <li>
+                    Deeper Erlang topics covered formal verification tools, error handling using <code>assert</code>,
+                    the scheduler, using TLA+ on GenServer, the new debugger in 28, <code>gen_statem</code>,
+                    optimization for 100+ core CPUs.
+                  </li>
+                </ul>
+
+                <p class="cta-wrap">
+                  <a class="cta" href="https://www.youtube.com/playlist?list=PLvL2NEhYV4Zsb00vrNRGm1db6CK53Yq5V" target="_blank">
+                    Watch the videos
+                  </a>
+                </p>
+              </div>
+            </div>
+
+            <div class="card">
+              <p class="eyebrow">CodeBEAM Satellite Events</p>
+
+              <div class="accent">
+                <p>
+                  The EEF coordinated events around CodeBEAM that extended the community experience.
+                  <a href="https://bitcrowd.net/en" target="_blank">bitcrowd</a> generously contributed space and coordinated local specialties like food.
+                </p>
+
+                <ul>
+                  <li>
+                    Tuesday evening: Nerves core member Gus Workman ran a hardware hands-on session that gave attendees experience writing a device driver
+                  </li>
+                  <li>
+                    Thursday evening: the Berlin meetup gathered after the close of CodeBEAM with topics from the conference and others
+                  </li>
+                  <li>
+                    Friday: Daniel Janowski organized the first Berlin BEAM Unconference with Josh Price (<a href="https://alembic.com.au" target="_blank">Alembic</a>)
+                    and Chris Beck (<a href="https://bitcrowd.net/de" target="_blank">bitcrowd</a>)… plus demos including <a href="https://eyg.run" target="_blank">EYG</a>
+                  </li>
+                </ul>
+
+                <p>
+                  We are working on a community side event for ElixirConf EU in Málaga, on either 22 or 25 April.
+                </p>
+              </div>
+            </div>
+
+            <div class="card">
+              <p class="eyebrow">ExMex</p>
+
+              <div class="accent">
+                <p>
+                  On November 6–7, the first <a href="https://exmexconf.com" target="_blank">ExMex</a> came to Austin, TX. In the words of Nathan Hessler:
+                </p>
+
+                <p>
+                  Running ExMex was a joy from start to finish. The energy in the room, the quality of the talks, and the feedback we received from attendees about how meaningful and impactful the event was made it clear this community thrives when we gather in person. We’re incredibly grateful to the Elixir Ecosystem Foundation for helping make this long-held vision a reality.
+                </p>
+              </div>
+            </div>
+
+            <p class="sub-title"><span class="u-underline">Security work</span></p>
+
+            <div class="card">
+              <p>There are three main areas of work in progress:</p>
+
+              <ul>
                 <li>
-                  <a href="https://atomvm.org" target="_blank">AtomVM</a> had talks covering the platform, the new JIT, and a lightning talk too. Conspiracy pundits expect next year’s CodeBEAM to have four AtomVM appearances.
+                  <a href="https://security.erlef.org/aegis/roadmap/source-sbom.html" target="_blank">Source SBOM</a>:
+                  Support in the default toolchain and integration into common industry tooling.
                 </li>
-                <li style="margin:0;"> Deeper Erlang topics covered formal verification tools, error handling using <span style="font-family:monospace;">assert</span>, the scheduler, using TLA+ on GenServer, the new debugger in 28, <span style="font-family:monospace;">gen_statem</span>, optimization for 100+ core CPUs. </li>
+                <li>
+                  <a href="https://security.erlef.org/aegis/roadmap/supply-chain-security-audit.html" target="_blank">Supply Chain Security Audit</a>:
+                  Audit Hex package manager, registry and integration into build tools (rebar3, mix, Gleam).
+                </li>
+              </ul>
+
+              <p>
+                For more information, <a href="https://security.erlef.org/aegis/" target="_blank">see Ægis</a>, the EEF Security Initiative.
+              </p>
+            </div>
+
+            <p class="sub-title"><span class="u-underline">Sponsors</span></p>
+
+            <div class="card">
+              <p class="bold">General sponsors</p>
+
+              <p>
+                We are happy to have some new and renewing sponsors that support the mission and work of the Foundation.
+              </p>
+
+              <ul>
+                <li><a href="https://www.emqx.com/en" target="_blank">EMQ</a>: The Unified MQTT Platform: Connect, process, and stream real-time data from millions of devices to any cloud, AI, and analytics. Turn massive IoT data into actionable intelligence with EMQX Platform.</li>
+                <li><a href="https://plausible.io" target="_blank">Plausible</a>: Easy to use and privacy-friendly Google Analytics alternative. Plausible is powerful, intuitive and lightweight analytics. No cookies just insights. Made and hosted in the EU, powered by European-owned infrastructure. 🇪🇺</li>
+                <li><a href="https://www.wyeworks.com" target="_blank">WyeWorks</a>: Inspiring people to build great software. We build software people love and enable companies to succeed.</li>
+                <li><a href="https://avassa.io" target="_blank">Avassa</a>: Remote, secure, and scalable application management in 10s, 100s, or 10 000s of edge locations.</li>
+                <li><a href="https://www.erlang-solutions.com" target="_blank">Erlang Solutions</a>: We build transformative solutions for the world’s most ambitious companies. By providing user-focused consultancy, high tech capabilities and connection to diverse communities.</li>
+                <li><a href="https://bitcrowd.net/en" target="_blank">bitcrowd</a>: The German consultancy for small to large companies (Deutsche Bahn and Red Bull to Lufthansa) for projects requiring greater agility. Specializing in Elixir, with Rust and Go, and as a significant Elixir AI contributor, also an excellent partner for your AI/ML projects.</li>
+                <li><a href="https://www.pharos-avantgard.com" target="_blank">Pharos Avantgard</a>: Pharos empowers communication service providers to save costs, accelerate revenue growth, and boost efficiency—so they can compete more effectively in the fast-moving, ever-evolving world of communications.</li>
+              </ul>
+
+              <p class="bold">Project sponsors</p>
+
+              <ul>
+                <li><span class="bold">OpenTelemetry</span> – Straw Hat, LLC (Yordis Prieto) contributed to advance Metrics.</li>
+                <li><span class="bold">Expert</span> – Enigmatic SA contributed to the Elixir language server.</li>
               </ul>
             </div>
-          </mj-text>
-          <mj-button mj-class="btnSecondary" href="https://www.youtube.com/playlist?list=PLvL2NEhYV4Zsb00vrNRGm1db6CK53Yq5V" align="left" padding="12px 0 0 0"> Watch the videos </mj-button>
-        </mj-column>
-      </mj-section>
-      <!-- Card: CodeBEAM Satellite -->
-      <mj-section background-color="#1f2c34" padding="0 24px 12px">
-        <mj-column>
-          <mj-text mj-class="card">
-            <p style="margin:0 0 8px 0; color:#8fa3ad; font-size:12px; letter-spacing:.02em; text-transform:uppercase;"> CodeBEAM Satellite Events </p>
-            <div style="border-left:4px solid #49b7ff; padding-left:12px;">
-              <p style="margin:0;"> The EEF coordinated events around CodeBEAM that extended the community experience. <a href="https://bitcrowd.net/en" target="_blank">bitcrowd</a> generously contributed space and coordinated local specialties like food. </p>
-              <ul style="margin:10px 0 0 18px; padding:0;">
-                <li>Tuesday evening: Nerves core member Gus Workman ran a hardware hands-on session that gave attendees experience writing a device driver</li>
-                <li>Thursday evening: the Berlin meetup gathered after the close of CodeBEAM with topics from the conference and others</li>
-                <li style="margin:0;">Friday: Daniel Janowski organized the first Berlin BEAM Unconference with Josh Price (<a href="https://alembic.com.au" target="_blank">Alembic</a>) and Chris Beck (<a href="https://bitcrowd.net/de" target="_blank">bitcrowd</a>)… plus demos including <a href="https://eyg.run" target="_blank">EYG</a></li>
-              </ul>
-              <p style="margin:10px 0 0 0;"> We are working on a community side event for ElixirConf EU in Málaga, on either 22 or 25 April. </p>
-            </div>
+
           </mj-text>
         </mj-column>
       </mj-section>
-      <!-- Card: ExMex -->
-      <mj-section background-color="#1f2c34" padding="0 24px 16px">
-        <mj-column>
-          <mj-text mj-class="card">
-            <p style="margin:0 0 8px 0; color:#8fa3ad; font-size:12px; letter-spacing:.02em; text-transform:uppercase;"> ExMex </p>
-            <div style="border-left:4px solid #49b7ff; padding-left:12px;">
-              <p style="margin:0;"> On November 6–7, the first <a href="https://exmexconf.com" target="_blank">ExMex</a> came to Austin, TX. In the words of Nathan Hessler: </p>
-              <p style="margin:10px 0 0 0; padding:0; color:#f2f2f2;"> Running ExMex was a joy from start to finish. The energy in the room, the quality of the talks, and the feedback we received from attendees about how meaningful and impactful the event was made it clear this community thrives when we gather in person. We’re incredibly grateful to the Elixir Ecosystem Foundation for helping make this long-held vision a reality. </p>
-            </div>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- SUBSECTION: Security work -->
-      <mj-section background-color="#1f2c34" padding="6px 24px 10px">
-        <mj-column>
-          <mj-text mj-class="subHeading barSub" align="left">
-            <span class="u-underline">Security work</span>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <mj-section background-color="#1f2c34" padding="0 24px 16px">
-        <mj-column>
-          <mj-text mj-class="card">
-            <p style="margin:0;">There are three main areas of work in progress:</p>
-            <ul style="margin:10px 0 0 18px; padding:0;">
-              <li><a href="https://security.erlef.org/aegis/roadmap/source-sbom.html" target="_blank">Source SBOM</a>: Support in the default toolchain and integration into common industry tooling.</li>
-              <li style="margin:0;"><a href="https://security.erlef.org/aegis/roadmap/supply-chain-security-audit.html" target="_blank">Supply Chain Security Audit</a>: Audit Hex package manager, registry and integration into build tools (rebar3, mix, Gleam).</li>
-            </ul>
-            <p style="margin:10px 0 0 0;">For more information, <a href="https://security.erlef.org/aegis/" target="_blank">see Ægis</a>, the EEF Security Initiative.</p>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- SUBSECTION: Sponsors -->
-      <mj-section background-color="#1f2c34" padding="6px 24px 10px">
-        <mj-column>
-          <mj-text mj-class="subHeading barSub" align="left">
-            <span class="u-underline">Sponsors</span>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <mj-section background-color="#1f2c34" padding="0 24px 18px">
-        <mj-column>
-          <mj-text mj-class="card">
-            <p style="margin:0; color:#f2f2f2; font-weight:700;">General sponsors</p>
-            <p style="margin:8px 0 12px 0;"> We are happy to have some new and renewing sponsors that support the mission and work of the Foundation. </p>
-            <ul style="margin:10px 0 0 18px; padding:0;">
-              <li><a href="https://www.emqx.com/en" target="_blank">EMQ</a>: The Unified MQTT Platform: Connect, process, and stream real-time data from millions of devices to any cloud, AI, and analytics. Turn massive IoT data into actionable intelligence with EMQX Platform.</li>
-              <li><a href="https://plausible.io" target="_blank">Plausible</a>: Easy to use and privacy-friendly Google Analytics alternative. Plausible is powerful, intuitive and lightweight analytics. No cookies just insights. Made and hosted in the EU, powered by European-owned infrastructure. 🇪🇺</li>
-              <li><a href="https://www.wyeworks.com" target="_blank">WyeWorks</a>: Inspiring people to build great software. We build software people love and enable companies to succeed.</li>
-              <li><a href="https://avassa.io" target="_blank">Avassa</a>: Remote, secure, and scalable application management in 10s, 100s, or 10 000s of edge locations.</li>
-              <li><a href="https://www.erlang-solutions.com" target="_blank">Erlang Solutions</a>: We build transformative solutions for the world’s most ambitious companies. By providing user-focused consultancy, high tech capabilities and connection to diverse communities.</li>
-              <li><a href="https://bitcrowd.net/en" target="_blank">bitcrowd</a>: The German consultancy for small to large companies (Deutsche Bahn and Red Bull to Lufthansa) for projects requiring greater agility. Specializing in Elixir, with Rust and Go, and as a significant Elixir AI contributor, also an excellent partner for your AI/ML projects.</li>
-              <li style="margin:0;"><a href="https://www.pharos-avantgard.com" target="_blank">Pharos Avantgard</a>: Pharos empowers communication service providers to save costs, accelerate revenue growth, and boost efficiency—so they can compete more effectively in the fast-moving, ever-evolving world of communications.</li>
-            </ul>
-            <p style="margin:14px 0 0 0; color:#f2f2f2; font-weight:700;">Project sponsors</p>
-            <ul style="margin:10px 0 0 18px; padding:0;">
-              <li><strong style="color:#f2f2f2;">OpenTelemetry</strong> – Straw Hat, LLC (Yordis Prieto) contributed to advance Metrics.</li>
-              <li style="margin:0;"><strong style="color:#f2f2f2;">Expert</strong> – Enigmatic SA contributed to the Elixir language server.</li>
-            </ul>
-          </mj-text>
-        </mj-column>
-      </mj-section>
-      <!-- Footer social -->
-      <mj-section background-color="#1f2c34" padding="0 24px 18px">
+
+      <!-- Footer -->
+      <mj-section padding="0 24px 18px">
         <mj-column align="center">
           <mj-divider />
           <mj-social font-size="13px" icon-size="28px" mode="horizontal" padding="14px 0 0 0" align="center">
@@ -210,6 +263,7 @@
           </mj-text>
         </mj-column>
       </mj-section>
+
     </mj-wrapper>
   </mj-body>
 </mjml>

--- a/news/mjml/template.mjml
+++ b/news/mjml/template.mjml
@@ -1,0 +1,196 @@
+<mjml>
+  <mj-head>
+    <!-- Webfont (note: some email clients ignore webfonts; keep fallbacks) -->
+    <mj-font name="Montserrat" href="https://fonts.googleapis.com/css?family=Montserrat:400,700" />
+
+    <!-- Preheader -->
+    <mj-preview>{{PREVIEW_TEXT}}</mj-preview>
+
+    <mj-attributes>
+      <mj-all font-family="Montserrat, Arial, Helvetica, sans-serif" />
+      <mj-section background-color="#ffffff" />
+      <mj-text font-size="14px" line-height="20px" color="#1f2c34" font-weight="400" padding="0" />
+      <mj-divider border-width="1px" border-color="#d6dde1" padding="0" />
+
+      <!-- Small utilities -->
+      <mj-class name="utility" font-size="12px" line-height="16px" color="#5a6b75" font-weight="400" />
+      <mj-class name="h1" font-size="24px" line-height="30px" color="#1f2c34" font-weight="700" />
+    </mj-attributes>
+
+    <!-- Centralized styling so editors only touch p/ul/li + links -->
+    <mj-style inline="inline">
+      a, a:link, a:visited, a:hover, a:active { color:#49b7ff; text-decoration:none; font-weight:700 !important; }
+
+      /* Keep editing simple: no inline margins in content */
+      p { margin: 0 0 10px 0; }
+      ul, ol { margin: 0; padding-left: 18px; }
+      li { margin: 0 0 8px 0; }
+
+      code { font-family: monospace; }
+      .bold { font-weight: 700 !important; }
+
+      /* Hierarchy */
+      .section-title {
+        margin: 18px 0 10px 0;
+        color: #49b7ff;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .sub-title {
+        margin: 32px 0 10px 0;
+        color: #1f2c34;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .u-underline { display:inline-block; border-bottom:2px solid #49b7ff; padding-bottom:2px; }
+
+      /* Content patterns */
+      .card { margin: 0 0 14px 0; padding: 0; }
+      .eyebrow {
+        margin: 0 0 8px 0;
+        color: #5a6b75;
+        font-size: 12px;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+      .accent { border-left: 4px solid #49b7ff; padding-left: 12px; }
+      .muted { color: #5a6b75; font-size: 12px; line-height: 18px; }
+
+      /* CTA-as-link (simple, no MJML button needed) */
+      .cta {
+        display: inline-block;
+        padding: 10px 14px;
+        border: 1px solid #c8d2d9;
+        border-radius: 10px;
+        background: #ffffff;
+        color: #49b7ff !important;
+        font-weight: 700 !important;
+        text-decoration: none !important;
+      }
+      .cta-wrap { margin: 12px 0 0 0; }
+
+      .hr { height: 1px; background: #d6dde1; margin: 16px 0; }
+    </mj-style>
+  </mj-head>
+
+  <!-- Light theme outer -->
+  <mj-body background-color="#fafafa" width="600px">
+
+    <!-- Utility row -->
+    <mj-section padding="24px 12px 12px">
+      <mj-column>
+        <mj-text mj-class="utility" align="center" padding="0 12px">
+          <a href="{{BROWSER_URL}}" target="_blank">Browser version ➚</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Main container -->
+    <mj-wrapper background-color="#ffffff" padding="0">
+
+      <!-- Header -->
+      <mj-section padding="20px 24px 12px">
+        <mj-column>
+          <mj-image
+            width="120px"
+            src="https://erlef.org/images/EEF_Isotipo.png"
+            alt="EEF Logo"
+            align="left"
+            padding="0"
+          />
+          <mj-text mj-class="h1" padding="12px 0 0 0">{{NEWSLETTER_TITLE}}</mj-text>
+          <mj-text mj-class="utility" padding="6px 0 0 0">{{NEWSLETTER_DATE}}</mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section padding="0 24px">
+        <mj-column><mj-divider /></mj-column>
+      </mj-section>
+
+      <!-- CONTENT: editors mainly edit p/ul/li below -->
+      <mj-section padding="0 24px 18px">
+        <mj-column>
+          <mj-text>
+            <!-- ========================= -->
+            <!-- TEMPLATE CONTENT START     -->
+            <!-- Copy/paste blocks + edit text/links only -->
+            <!-- ========================= -->
+
+            <!-- SECTION -->
+            <p class="section-title">Section title</p>
+
+            <!-- SUBSECTION -->
+            <p class="sub-title"><span class="u-underline">Subsection title</span></p>
+
+            <!-- GENERIC CARD -->
+            <div class="card">
+              <p>Write your paragraph here. Link example: <a href="https://example.com" target="_blank">example</a>.</p>
+              <ul>
+                <li>Bullet one</li>
+                <li>Bullet two</li>
+              </ul>
+              <p class="muted">Optional helper line (muted).</p>
+            </div>
+
+            <!-- DIVIDER -->
+            <div class="hr"></div>
+
+            <!-- EVENT CARD (eyebrow + accent) -->
+            <div class="card">
+              <p class="eyebrow">Event name (City)</p>
+              <div class="accent">
+                <ul>
+                  <li>Point one (use <code>code</code> for inline code)</li>
+                  <li>Point two</li>
+                </ul>
+                <p class="cta-wrap">
+                  <a class="cta" href="https://example.com" target="_blank">CTA link</a>
+                </p>
+              </div>
+            </div>
+
+            <!-- SPONSORS CARD (simple) -->
+            <p class="sub-title"><span class="u-underline">Sponsors</span></p>
+
+            <div class="card">
+              <p class="bold">General sponsors</p>
+              <p>Intro sentence about sponsors.</p>
+              <ul>
+                <li><a href="https://example.com" target="_blank">Sponsor</a>: one-line description.</li>
+                <li><a href="https://example.com" target="_blank">Sponsor</a>: one-line description.</li>
+              </ul>
+
+              <p class="bold" style="margin-top:14px;">Project sponsors</p>
+              <ul>
+                <li><span class="bold">Project</span> – sponsor details.</li>
+                <li><span class="bold">Project</span> – sponsor details.</li>
+              </ul>
+            </div>
+
+            <!-- ========================= -->
+            <!-- TEMPLATE CONTENT END       -->
+            <!-- ========================= -->
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+      <!-- Footer -->
+      <mj-section padding="0 24px 18px">
+        <mj-column align="center">
+          <mj-divider />
+          <mj-social font-size="13px" icon-size="28px" mode="horizontal" padding="14px 0 0 0" align="center">
+            <mj-social-element name="twitter" href="https://x.com/TheErlef" />
+            <mj-social-element name="github" href="https://github.com/erlef" />
+            <mj-social-element name="linkedin" href="https://www.linkedin.com/company/erlef" />
+          </mj-social>
+          <mj-text mj-class="utility" align="center" padding="10px 0 0 0">
+            <a href="{Unsubscribe_Url}" target="_blank">Unsubscribe</a>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
- Updated **template-example** to a simpler, content-first format (mostly p/ul/li) with a light theme and more reliable bold styling
- Added a new **template** using the same simplified structure for future newsletters
- Added a **README** with placeholders, editing patterns, and build/preview instructions