### PR TITLE
Fix registry announce title link

### DIFF
--- a/mjml/registry-announce.mjml
+++ b/mjml/registry-announce.mjml
@@ -51,12 +51,12 @@
           <mj-text>
             
             <!-- SECTION -->
-            <p class="section-title">Announcing <a href="registry.erlef.org">registry.erlef.org</a></p>
+            <p class="section-title">Announcing <a href="https://registry.erlef.org" target="_blank">registry.erlef.org</a></p>
 
             <p>
               Today you'll find something new
               at <a href="https://registry.erlef.org"
-              target="_new">registry.erlef.org</a>. As the
+              target="_blank">registry.erlef.org</a>. As the
               the <b>Erlang Ecosystem Foundation</b> works to serve
               its members, sponsors and ecosystem we believe in the
               value of a canonical, central and trusted company

--- a/news/registry-announce.html
+++ b/news/registry-announce.html
@@ -318,8 +318,8 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
                                   <div style="font-family:Montserrat, Arial, Helvetica, sans-serif;font-size:14px;font-weight:400;line-height:20px;text-align:left;color:#1f2c34;"><!-- SECTION -->
-                                    <p class="section-title">Announcing <a href="registry.erlef.org">registry.erlef.org</a></p>
-                                    <p> Today you'll find something new at <a href="https://registry.erlef.org" target="_new">registry.erlef.org</a>. As the the <b>Erlang Ecosystem Foundation</b> works to serve its members, sponsors and ecosystem we believe in the value of a canonical, central and trusted company registry. </p>
+                                    <p class="section-title">Announcing <a href="https://registry.erlef.org" target="_blank">registry.erlef.org</a></p>
+                                    <p> Today you'll find something new at <a href="https://registry.erlef.org" target="_blank">registry.erlef.org</a>. As the the <b>Erlang Ecosystem Foundation</b> works to serve its members, sponsors and ecosystem we believe in the value of a canonical, central and trusted company registry. </p>
                                     <p> Together we can answer the key question "who uses this?" Populating this registry with companies working within the Erlang ecosystem, with any of the <a href="https://erlef.org/community/">more than 16 languages</a>, will shine a light on the significant scope of our ecosystem. </p>
                                     <p> It benefits individual members (as workers and buyers) in finding companies using the technologies they know and trust. It benefits the companies as we can keep them updated on the ongoing work in the ecosystem, inform about risks and mediate opportunities in the community. It also supports foundation efforts when seeking funding by showing evidence of ecosystem size and engagement. </p>
                                     <p>


### PR DESCRIPTION
### Summary

Fixes the broken title link on the registry announcement page. The registry.erlef.org href was missing https://, so it resolved as a relative URL. 
Also standardizes both registry links to use target="_blank" (replacing non-standard _new on the body link).